### PR TITLE
CVSBB-17157 - retry up to X times on error

### DIFF
--- a/src/functions/certGenInit.ts
+++ b/src/functions/certGenInit.ts
@@ -12,8 +12,7 @@ import { Utils } from "../utils/Utils";
  * @param context - λ Context
  * @param callback - callback function
  */
-const certGenInit: Handler = async (event: any, context?: Context, callback?: Callback):
-Promise<void | Array<PromiseResult<SendMessageResult, AWSError>>> => {
+const certGenInit: Handler = async (event: any, context?: Context, callback?: Callback): Promise<void | Array<PromiseResult<SendMessageResult, AWSError>>> => {
   if (!event) {
     console.error("ERROR: event is not defined.");
     return;
@@ -21,25 +20,18 @@ Promise<void | Array<PromiseResult<SendMessageResult, AWSError>>> => {
 
   // Convert the received event into a readable array of filtered test results
   const expandedRecords: any[] = StreamService.getTestResultStream(event);
-  const certGenFilteredRecords: any[] = Utils.filterCertificateGenerationRecords(
-    expandedRecords
-  );
+  const certGenFilteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
   // Instantiate the Simple Queue Service
   const sqService: SQService = new SQService(new SQS());
   const sendMessagePromises: Array<Promise<PromiseResult<SendMessageResult, AWSError>>> = [];
 
   certGenFilteredRecords.forEach((record: any) => {
-      sendMessagePromises.push(
-        sqService.sendCertGenMessage(JSON.stringify(record))
-      );
+      sendMessagePromises.push(sqService.sendCertGenMessage(JSON.stringify(record)));
   });
 
   expandedRecords.forEach((record: any) => {
-      sendMessagePromises.push(
-        sqService.sendUpdateStatusMessage(JSON.stringify(record))
-      );
-
+      sendMessagePromises.push(sqService.sendUpdateStatusMessage(JSON.stringify(record)));
   });
 
   return Promise.all(sendMessagePromises).catch((error: AWSError) => {
@@ -48,9 +40,8 @@ Promise<void | Array<PromiseResult<SendMessageResult, AWSError>>> => {
     console.log(JSON.stringify(expandedRecords));
     console.log("certGenFilteredRecords");
     console.log(JSON.stringify(certGenFilteredRecords));
-    if (error.code !== "InvalidParameterValue") {
-        throw error;
-    }
+    // Lambda will retry up to X times or until the message expires, after which the message will be sent to the dlq.
+    throw error;
   });
 };
 

--- a/tests/unit/certGenInitFunction.unitTest.ts
+++ b/tests/unit/certGenInitFunction.unitTest.ts
@@ -49,7 +49,7 @@ describe("certGenInit Function", () => {
   });
 
   describe("when SQService throws error", () => {
-    it("should throw error if code is not InvalidParameterValue", async () => {
+    it("should throw error", async () => {
       StreamService.getTestResultStream = jest.fn().mockReturnValue([{}]);
       const myError = new Error("It Broke!") as AWSError;
       myError.code = "SomeError";
@@ -65,24 +65,6 @@ describe("certGenInit Function", () => {
       } catch (e) {
         expect(e.message).toEqual(myError.message);
         expect(e.code).toEqual(myError.code);
-      }
-    });
-    it("should not throw error if code is InvalidParameterValue", async () => {
-      StreamService.getTestResultStream = jest.fn().mockReturnValue([{}]);
-      const myError = new Error("It Broke!") as AWSError;
-      myError.code = "InvalidParameterValue";
-      SQService.prototype.sendCertGenMessage = jest.fn().mockRejectedValue(myError);
-      SQService.prototype.sendUpdateStatusMessage = jest.fn();
-      StreamService.getTestResultStream = jest.fn().mockReturnValue([{test: "thing"}]);
-      Utils.filterCertificateGenerationRecords = jest.fn().mockReturnValue([{test: "thing"}]);
-
-
-      expect.assertions(1);
-      try {
-        const result = await certGenInit({}, ctx, () => { return; });
-        expect(result).toBe({});
-      } catch (e) {
-        console.log(e);
       }
     });
   });


### PR DESCRIPTION
This ticket covers the work required to fix EDH marshaller lambda which sometimes fails when the payload is too big (It returns 413 errors)

If the lambda fails to process the message and throws an error, then it will log the error and it will retry up to X times (configurable from AWS, currently set to 3 times) or until the message expires (60 seconds), after which it will send the message to the respective DLQs for further investigation.

https://jira.dvsacloud.uk/browse/CVSB-17157