### PR TITLE
CB2-9865: Failed IVA test triggers cert-gen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,11 +79,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -201,11 +201,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dependencies": {
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -240,20 +240,20 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -334,17 +334,17 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -373,11 +373,11 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.15.tgz",
-      "integrity": "sha512-RWmQ/sklUN9BvGGpCDgSubhHWfAx24XDTDObup4ffvxaYsptOg2P3KG0j+1eWKLxpkX0j0uHxmpq2Z1SP/VhxA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -643,19 +643,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.15.tgz",
-      "integrity": "sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -663,12 +663,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.15.tgz",
-      "integrity": "sha512-X+NLXr0N8XXmN5ZsaQdm9U2SSC3UbIYq/doL++sueHOTisgZHoKaQtZxGuV2cUPQHMfjKEfg/g6oy7Hm6SKFtA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.15",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -2014,14 +2014,14 @@
       }
     },
     "node_modules/@serverless/platform-client": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.3.2.tgz",
-      "integrity": "sha512-DAa5Z0JAZc6UfrTZLYwqoZxgAponZpFwaqd7WzzMA+loMCkYWyJNwxrAmV6cr2UUJpkko4toPZuJ3vM9Ie+NDA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.5.1.tgz",
+      "integrity": "sha512-XltmO/029X76zi0LUFmhsnanhE2wnqH1xf+WBt5K8gumQA9LnrfwLgPxj+VA+mm6wQhy+PCp7H5SS0ZPu7F2Cw==",
       "dev": true,
       "dependencies": {
         "adm-zip": "^0.5.5",
         "archiver": "^5.3.0",
-        "axios": "^0.21.1",
+        "axios": "^1.6.2",
         "fast-glob": "^3.2.7",
         "https-proxy-agent": "^5.0.0",
         "ignore": "^5.1.8",
@@ -3568,12 +3568,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-eslint": {
@@ -6472,9 +6474,9 @@
       "peer": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "dev": true,
       "funding": [
         {
@@ -11226,6 +11228,12 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "dev": true
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -14579,11 +14587,11 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "requires": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "dependencies": {
@@ -14677,11 +14685,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "requires": {
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -14709,17 +14717,17 @@
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q=="
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA=="
     },
     "@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "requires": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -14776,14 +14784,14 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ=="
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ=="
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/helper-validator-option": {
       "version": "7.22.15",
@@ -14803,11 +14811,11 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -14859,9 +14867,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.15.tgz",
-      "integrity": "sha512-RWmQ/sklUN9BvGGpCDgSubhHWfAx24XDTDObup4ffvxaYsptOg2P3KG0j+1eWKLxpkX0j0uHxmpq2Z1SP/VhxA=="
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -15000,29 +15008,29 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.15.tgz",
-      "integrity": "sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.15.tgz",
-      "integrity": "sha512-X+NLXr0N8XXmN5ZsaQdm9U2SSC3UbIYq/doL++sueHOTisgZHoKaQtZxGuV2cUPQHMfjKEfg/g6oy7Hm6SKFtA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
       "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.15",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -16106,14 +16114,14 @@
       }
     },
     "@serverless/platform-client": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.3.2.tgz",
-      "integrity": "sha512-DAa5Z0JAZc6UfrTZLYwqoZxgAponZpFwaqd7WzzMA+loMCkYWyJNwxrAmV6cr2UUJpkko4toPZuJ3vM9Ie+NDA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.5.1.tgz",
+      "integrity": "sha512-XltmO/029X76zi0LUFmhsnanhE2wnqH1xf+WBt5K8gumQA9LnrfwLgPxj+VA+mm6wQhy+PCp7H5SS0ZPu7F2Cw==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.5.5",
         "archiver": "^5.3.0",
-        "axios": "^0.21.1",
+        "axios": "^1.6.2",
         "fast-glob": "^3.2.7",
         "https-proxy-agent": "^5.0.0",
         "ignore": "^5.1.8",
@@ -17405,12 +17413,14 @@
       }
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-eslint": {
@@ -19721,9 +19731,9 @@
       "peer": true
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "dev": true
     },
     "for-each": {
@@ -23365,6 +23375,12 @@
           "dev": true
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -25,9 +25,11 @@ export class Utils {
         if (record.testTypes && record.testTypes.testTypeClassification) {
           return (
             record.testTypes.testTypeClassification === "Annual With Certificate" ||
-            record.testTypes.testTypeClassification === "IVA With Certificate" &&
-            record.testTypes.testResult === "fail" &&
-            record.testTypes.ivaDefects && record.testTypes.ivaDefects.length > 0
+            (
+                record.testTypes.testTypeClassification === "IVA With Certificate" &&
+                record.testTypes.testResult === "fail" &&
+                record.testTypes.ivaDefects && record.testTypes.ivaDefects.length > 0
+              )
           );
         }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -24,8 +24,8 @@ export class Utils {
         // Filter by testTypeClassification
         if (record.testTypes && record.testTypes.testTypeClassification) {
           return (
-            record.testTypes.testTypeClassification ===
-            "Annual With Certificate"
+            record.testTypes.testTypeClassification === "Annual With Certificate" ||
+            record.testTypes.testTypeClassification === "IVA With Certificate" && record.testTypes.testResult === "fail"
           );
         }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -29,7 +29,7 @@ export class Utils {
                 record.testTypes.testTypeClassification === "IVA With Certificate" &&
                 record.testTypes.testResult === "fail" &&
                 record.testTypes.ivaDefects && record.testTypes.ivaDefects.length > 0
-              )
+            )
           );
         }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -22,18 +22,14 @@ export class Utils {
       })
       .filter((record: any) => {
         // Filter by testTypeClassification or testTypeClassification, testResult and ivaDefects present and populated
-        if (record.testTypes && record.testTypes.testTypeClassification) {
-          return (
-            record.testTypes.testTypeClassification === "Annual With Certificate" ||
-            (
-                record.testTypes.testTypeClassification === "IVA With Certificate" &&
-                record.testTypes.testResult === "fail" &&
-                record.testTypes.ivaDefects && record.testTypes.ivaDefects.length > 0
-            )
-          );
-        }
+        const testTypes = record.testTypes;
 
-        return false;
+        const isAnnualWithCertificate = testTypes?.testTypeClassification === "Annual With Certificate";
+        const isIvaWithCertificate = testTypes?.testTypeClassification === "IVA With Certificate";
+        const isTestResultFail = testTypes?.testResult === "fail";
+        const hasNonEmptyIvaDefects = !!(testTypes?.ivaDefects?.length);
+
+        return isAnnualWithCertificate || (isIvaWithCertificate && isTestResultFail && hasNonEmptyIvaDefects);
       });
   }
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -21,11 +21,13 @@ export class Utils {
         );
       })
       .filter((record: any) => {
-        // Filter by testTypeClassification
+        // Filter by testTypeClassification or testTypeClassification, testResult and ivaDefects present and populated
         if (record.testTypes && record.testTypes.testTypeClassification) {
           return (
             record.testTypes.testTypeClassification === "Annual With Certificate" ||
-            record.testTypes.testTypeClassification === "IVA With Certificate" && record.testTypes.testResult === "fail"
+            record.testTypes.testTypeClassification === "IVA With Certificate" &&
+            record.testTypes.testResult === "fail" &&
+            record.testTypes.ivaDefects && record.testTypes.ivaDefects.length > 0
           );
         }
 

--- a/tests/unit/certGenInit.unitTest.ts
+++ b/tests/unit/certGenInit.unitTest.ts
@@ -6,6 +6,7 @@ import { PromiseResult } from "aws-sdk/lib/request";
 import { ReceiveMessageResult, SendMessageResult } from "aws-sdk/clients/sqs";
 import { AWSError } from "aws-sdk";
 import event from "../resources/stream-event.json";
+import {Configuration} from "../../src/utils/Configuration";
 
 describe("cert-gen-init", () => {
   let processedEvent: any;
@@ -203,6 +204,24 @@ describe("cert-gen-init", () => {
                 QueueUrl: "sqs://queue/cert-gen-q",
               });
             });
+        });
+
+        it("should log an error when SQS config is not defined", () => {
+          const logSpy = jest.spyOn(console, "error");
+          Configuration.prototype.getConfig = jest.fn().mockReturnValue({sqs: undefined});
+
+          try {
+            Injector.resolve<SQService>(SQService, [
+              SQMockClient,
+            ]);
+            expect(logSpy).toHaveBeenCalledTimes(1);
+            expect(logSpy).toHaveBeenCalledWith("SQS config is not defined in the config file.");
+          } catch (error) {
+            // do nothing
+          }
+
+          logSpy.mockClear();
+          jest.clearAllMocks();
         });
       });
     });

--- a/tests/unit/utils.unitTest.ts
+++ b/tests/unit/utils.unitTest.ts
@@ -15,7 +15,7 @@ describe("utils", () => {
   });
 
   describe("when filtering dynamoDB streams events", () => {
-    it("should filter correctly cancelled tests", async () => {
+    it("should filter correctly cancelled tests", () => {
       expandedRecords[0].testStatus = "cancelled";
       const filteredRecords: any[] =
         Utils.filterCertificateGenerationRecords(expandedRecords);
@@ -23,7 +23,7 @@ describe("utils", () => {
       expect(filteredRecords.length).toBe(0);
     });
 
-    it("should filter correctly abandoned testTypes", async () => {
+    it("should filter correctly abandoned testTypes", () => {
       console.log(expandedRecords[0]);
       expandedRecords[0].testTypes.testResult = "abandoned";
       const filteredRecords: any[] =
@@ -32,14 +32,14 @@ describe("utils", () => {
       expect(filteredRecords.length).toBe(0);
     });
 
-    it("should not remove events which have to generate a certificate", async () => {
+    it("should not remove events which have to generate a certificate", () => {
       const filteredRecords: any[] =
         Utils.filterCertificateGenerationRecords(expandedRecords);
 
       expect(filteredRecords).toEqual(expandedRecords);
     });
 
-    it("should filter correctly events without a testTypeClassification ", async () => {
+    it("should filter correctly events without a testTypeClassification ", () => {
       delete expandedRecords[0].testTypes.testTypeClassification;
       const filteredRecords: any[] =
         Utils.filterCertificateGenerationRecords(expandedRecords);
@@ -47,7 +47,7 @@ describe("utils", () => {
       expect(filteredRecords.length).toBe(0);
     });
 
-    it("should filter correctly events that have IVA With Certificate, ivaDefects populated but not test result fail", async () => {
+    it("should filter correctly events that have IVA With Certificate, ivaDefects populated but not test result fail", () => {
       expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
       expandedRecords[0].testTypes.ivaDefects = [{}];
       expandedRecords[0].testTypes.testResult = "pass";
@@ -56,7 +56,7 @@ describe("utils", () => {
       expect(filteredRecords.length).toBe(0);
     });
 
-    it("should filter correctly events that have IVA With Certificate, test result fail but no ivaDefects", async () => {
+    it("should filter correctly events that have IVA With Certificate, test result fail but no ivaDefects", () => {
         expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
         expandedRecords[0].testTypes.testResult = "fail";
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
@@ -64,7 +64,7 @@ describe("utils", () => {
         expect(filteredRecords.length).toBe(0);
     });
 
-    it("should filter correctly events that have IVA With Certificate, test result fail but empty ivaDefects", async () => {
+    it("should filter correctly events that have IVA With Certificate, test result fail but empty ivaDefects", () => {
         expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
         expandedRecords[0].testTypes.testResult = "fail";
         expandedRecords[0].testTypes.ivaDefects = [];
@@ -73,7 +73,7 @@ describe("utils", () => {
         expect(filteredRecords.length).toBe(0);
     });
 
-    it("should not remove events which have IVA With Certificate, ivaDefects and test result fail", async () => {
+    it("should not remove events which have IVA With Certificate, ivaDefects and test result fail", () => {
       expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
       expandedRecords[0].testTypes.testResult = "fail";
       expandedRecords[0].testTypes.ivaDefects = [{}];
@@ -82,14 +82,14 @@ describe("utils", () => {
       expect(filteredRecords).toEqual(expandedRecords);
     });
 
-    it("should not remove events which have Annual With Certificate, no ivaDefects and test result fail", async () => {
+    it("should not remove events which have Annual With Certificate, no ivaDefects and test result fail", () => {
         expandedRecords[0].testTypes.testResult = "fail";
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
         expect(filteredRecords).toEqual(expandedRecords);
     });
 
-    it("should not remove events which have Annual With Certificate, empty ivaDefects and test result fail", async () => {
+    it("should not remove events which have Annual With Certificate, empty ivaDefects and test result fail", () => {
         expandedRecords[0].testTypes.ivaDefects = [];
         expandedRecords[0].testTypes.testResult = "fail";
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
@@ -97,7 +97,7 @@ describe("utils", () => {
         expect(filteredRecords).toEqual(expandedRecords);
     });
 
-    it("should not remove events which have Annual With Certificate, populated ivaDefects and test result fail", async () => {
+    it("should not remove events which have Annual With Certificate, populated ivaDefects and test result fail", () => {
         expandedRecords[0].testTypes.ivaDefects = [{}];
         expandedRecords[0].testTypes.testResult = "fail";
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);

--- a/tests/unit/utils.unitTest.ts
+++ b/tests/unit/utils.unitTest.ts
@@ -47,20 +47,62 @@ describe("utils", () => {
       expect(filteredRecords.length).toBe(0);
     });
 
-    it("should filter correctly events that are IVA With Certificate but not test result fail", async () => {
+    it("should filter correctly events that have IVA With Certificate, ivaDefects populated but not test result fail", async () => {
       expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
+      expandedRecords[0].testTypes.ivaDefects = [{}];
       expandedRecords[0].testTypes.testResult = "pass";
       const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
       expect(filteredRecords.length).toBe(0);
     });
 
-    it("should not remove events which have IVA With Certificate and do have test result fail", async () => {
+    it("should filter correctly events that have IVA With Certificate, test result fail but no ivaDefects", async () => {
+        expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
+        expandedRecords[0].testTypes.testResult = "fail";
+        const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
+
+        expect(filteredRecords.length).toBe(0);
+    });
+
+    it("should filter correctly events that have IVA With Certificate, test result fail but empty ivaDefects", async () => {
+        expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
+        expandedRecords[0].testTypes.testResult = "fail";
+        expandedRecords[0].testTypes.ivaDefects = [];
+        const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
+
+        expect(filteredRecords.length).toBe(0);
+    });
+
+    it("should not remove events which have IVA With Certificate, ivaDefects and test result fail", async () => {
       expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
       expandedRecords[0].testTypes.testResult = "fail";
+      expandedRecords[0].testTypes.ivaDefects = [{}];
       const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
       expect(filteredRecords).toEqual(expandedRecords);
+    });
+
+    it("should not remove events which have Annual With Certificate, no ivaDefects and test result fail", async () => {
+        expandedRecords[0].testTypes.testResult = "fail";
+        const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
+
+        expect(filteredRecords).toEqual(expandedRecords);
+    });
+
+    it("should not remove events which have Annual With Certificate, empty ivaDefects and test result fail", async () => {
+        expandedRecords[0].testTypes.ivaDefects = [];
+        expandedRecords[0].testTypes.testResult = "fail";
+        const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
+
+        expect(filteredRecords).toEqual(expandedRecords);
+    });
+
+    it("should not remove events which have Annual With Certificate, populated ivaDefects and test result fail", async () => {
+        expandedRecords[0].testTypes.ivaDefects = [{}];
+        expandedRecords[0].testTypes.testResult = "fail";
+        const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
+
+        expect(filteredRecords).toEqual(expandedRecords);
     });
   });
 });

--- a/tests/unit/utils.unitTest.ts
+++ b/tests/unit/utils.unitTest.ts
@@ -46,5 +46,21 @@ describe("utils", () => {
 
       expect(filteredRecords.length).toBe(0);
     });
+
+    it("should filter correctly events that are IVA With Certificate but not test result fail", async () => {
+      expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
+      expandedRecords[0].testTypes.testResult = "pass";
+      const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
+
+      expect(filteredRecords.length).toBe(0);
+    });
+
+    it("should not remove events which have IVA With Certificate and do have test result fail", async () => {
+      expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
+      expandedRecords[0].testTypes.testResult = "fail";
+      const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
+
+      expect(filteredRecords).toEqual(expandedRecords);
+    });
   });
 });


### PR DESCRIPTION
## Ticket title

The changes made as part of this PR ensure that an event is only passed onto the appropriate cert-gen SQS when the following has been met:
- test result test type ID is an IVA test type id
- test result is fail
- ivaDefects array is present and populated (this should only be the case for M1 euVhicleCategories currently)

Also bumped babel due to crit vulnerability as per npm audit.

[CB2-9865](https://dvsa.atlassian.net/browse/CB2-9865)

This is going into the IVA holding branch (CB2-30) until the corresponding tickets CB2-9866, CB2-9640 and CB2-9976 are completed. All will go into develop at the same time.

## Checklist

- [X] Branch is rebased against the latest develop/common
- [X] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [X] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [X] Link to the PR added to the repo
- [ ] Delete branch after merge
