### PR TITLE
CB2-10870: Refactor Cert Gen Init ivaDefects to requiredStandards

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -21,15 +21,15 @@ export class Utils {
         );
       })
       .filter((record: any) => {
-        // Filter by testTypeClassification or testTypeClassification, testResult and ivaDefects present and populated
+        // Filter by testTypeClassification or testTypeClassification, testResult and requiredStandards present and populated
         const testTypes = record.testTypes;
 
         const isAnnualWithCertificate = testTypes?.testTypeClassification === "Annual With Certificate";
         const isIvaWithCertificate = testTypes?.testTypeClassification === "IVA With Certificate";
         const isTestResultFail = testTypes?.testResult === "fail";
-        const hasNonEmptyIvaDefects = !!(testTypes?.ivaDefects?.length);
+        const hasNonEmptyRequiredStandards = !!(testTypes?.requiredStandards?.length);
 
-        return isAnnualWithCertificate || (isIvaWithCertificate && isTestResultFail && hasNonEmptyIvaDefects);
+        return isAnnualWithCertificate || (isIvaWithCertificate && isTestResultFail && hasNonEmptyRequiredStandards);
       });
   }
 }

--- a/tests/unit/utils.unitTest.ts
+++ b/tests/unit/utils.unitTest.ts
@@ -47,16 +47,16 @@ describe("utils", () => {
       expect(filteredRecords.length).toBe(0);
     });
 
-    it("should filter correctly events that have IVA With Certificate, ivaDefects populated but not test result fail", () => {
+    it("should filter correctly events that have IVA With Certificate, requiredStandards populated but not test result fail", () => {
       expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
-      expandedRecords[0].testTypes.ivaDefects = [{}];
+      expandedRecords[0].testTypes.requiredStandards = [{}];
       expandedRecords[0].testTypes.testResult = "pass";
       const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
       expect(filteredRecords.length).toBe(0);
     });
 
-    it("should filter correctly events that have IVA With Certificate, test result fail but no ivaDefects", () => {
+    it("should filter correctly events that have IVA With Certificate, test result fail but no requiredStandards", () => {
         expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
         expandedRecords[0].testTypes.testResult = "fail";
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
@@ -64,41 +64,41 @@ describe("utils", () => {
         expect(filteredRecords.length).toBe(0);
     });
 
-    it("should filter correctly events that have IVA With Certificate, test result fail but empty ivaDefects", () => {
+    it("should filter correctly events that have IVA With Certificate, test result fail but empty requiredStandards", () => {
         expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
         expandedRecords[0].testTypes.testResult = "fail";
-        expandedRecords[0].testTypes.ivaDefects = [];
+        expandedRecords[0].testTypes.requiredStandards = [];
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
         expect(filteredRecords.length).toBe(0);
     });
 
-    it("should not remove events which have IVA With Certificate, ivaDefects and test result fail", () => {
+    it("should not remove events which have IVA With Certificate, requiredStandards and test result fail", () => {
       expandedRecords[0].testTypes.testTypeClassification = "IVA With Certificate";
       expandedRecords[0].testTypes.testResult = "fail";
-      expandedRecords[0].testTypes.ivaDefects = [{}];
+      expandedRecords[0].testTypes.requiredStandards = [{}];
       const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
       expect(filteredRecords).toEqual(expandedRecords);
     });
 
-    it("should not remove events which have Annual With Certificate, no ivaDefects and test result fail", () => {
+    it("should not remove events which have Annual With Certificate, no requiredStandards and test result fail", () => {
         expandedRecords[0].testTypes.testResult = "fail";
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
         expect(filteredRecords).toEqual(expandedRecords);
     });
 
-    it("should not remove events which have Annual With Certificate, empty ivaDefects and test result fail", () => {
-        expandedRecords[0].testTypes.ivaDefects = [];
+    it("should not remove events which have Annual With Certificate, empty requiredStandards and test result fail", () => {
+        expandedRecords[0].testTypes.requiredStandards = [];
         expandedRecords[0].testTypes.testResult = "fail";
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 
         expect(filteredRecords).toEqual(expandedRecords);
     });
 
-    it("should not remove events which have Annual With Certificate, populated ivaDefects and test result fail", () => {
-        expandedRecords[0].testTypes.ivaDefects = [{}];
+    it("should not remove events which have Annual With Certificate, populated requiredStandards and test result fail", () => {
+        expandedRecords[0].testTypes.requiredStandards = [{}];
         expandedRecords[0].testTypes.testResult = "fail";
         const filteredRecords: any[] = Utils.filterCertificateGenerationRecords(expandedRecords);
 


### PR DESCRIPTION
## Refactor cert-gen init from ivaDefects to requiredStandards

Replacing ivaDefects with requiredStandards will allow re-use of the same objects for MSVA as well as IVA.

This also brings terminology in-line with DVSA policy and VTA/VTM apps.

[CB2-10870](https://dvsa.atlassian.net/browse/CB2-10870)

## Checklist

- [X] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [X] Code and UI has been tested manually after the additional changes
- [X] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [X] Link to the PR added to the repo
- [ ] Delete branch after merge
